### PR TITLE
Clean Up ReadMe and Gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or you can instantiate with a block
 
 After instantiating, you can make a request to the Edamam foodrequest api
 ```
-    nutritional_data = client.food_request.nutritional_data("1 large apple")
+    nutritional_data = client.food_database.nutritional_data("1 large apple")
 ```
 This would return an object which has all the successfull fields from [Edamam api](https://developer.edamam.com/edamam-docs-nutrition-api).
 

--- a/edamam-ruby.gemspec
+++ b/edamam-ruby.gemspec
@@ -6,8 +6,8 @@ require 'edamam-ruby/version'
 Gem::Specification.new do |spec|
   spec.name          = "edamam-ruby"
   spec.version       = Edamam::VERSION
-  spec.authors       = ["Olalekan Eyiowuawi"]
-  spec.email         = ["olalekan.eyiowuawi@andela.com"]
+  spec.authors       = ["Olalekan Eyiowuawi", "Chris Woodford", "Mayowa Pitan"]
+  spec.email         = ["olalekan.eyiowuawi@andela.com", "chris@gobble.com", "mayowa.pitan@andela.com"]
 
   spec.summary       = %q{This a ruby wrapper for the Edamam Nutrition api}
   spec.description   = %q{This a ruby wrapper for the Edamam Nutrition api}
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata['allowed_push_host'] = "https://rubygems.org"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."


### PR DESCRIPTION
Clean Up ReadMe and Gemspec

The Readme contains an error which can be misleading to users of the gem. Also Gemspec file has to be updated so that the gem can be pushed to `rubygems`

This change addresses this need by:

* removing `food_request` on the readme and adding `food_database`

* adding `rubygems` as host of the gem

* adding the authors

Resolves #7 